### PR TITLE
Fixing the VS2012 .sln file, so it opens in Visual Studio

### DIFF
--- a/Clide.2012.sln
+++ b/Clide.2012.sln
@@ -1,6 +1,6 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 13.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Clide", "Src\Clide\Clide.csproj", "{EAF59C6D-A973-48E6-A90A-5E894ECEC3F6}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IntegrationTests", "Src\IntegrationTests\IntegrationTests.csproj", "{DA6BC069-580E-4248-9E38-F20BDE688271}"


### PR DESCRIPTION
The VS2012.sln file was modified such that it wouldn't open with Visual Studio 2012. This fixes the issue.

(Did you save this file with vs13?)
