### PR TITLE
Fallback UniqueName to project full name if it fails

### DIFF
--- a/src/Clide/Adapters/DteToVsAdapter.cs
+++ b/src/Clide/Adapters/DteToVsAdapter.cs
@@ -35,7 +35,7 @@ namespace Clide.Adapters
 
 			if (!ErrorHandler.Succeeded (serviceProvider
 				.GetService<SVsSolution, IVsSolution> ()
-				.GetProjectOfUniqueName (from.UniqueName, out project)))
+				.GetProjectOfUniqueName (from.GetUniqueNameOrFullName(), out project)))
 				return null;
 
 			return project as IVsProject;
@@ -50,7 +50,7 @@ namespace Clide.Adapters
 
 			if (!ErrorHandler.Succeeded (this.serviceProvider
 				.GetService<SVsSolution, IVsSolution> ()
-				.GetProjectOfUniqueName (from.UniqueName, out project)))
+				.GetProjectOfUniqueName (from.GetUniqueNameOrFullName(), out project)))
 				return null;
 
 			return hierarchyManager.GetHierarchyItem (project, VSConstants.VSITEMID_ROOT);
@@ -62,7 +62,7 @@ namespace Clide.Adapters
 
 			if (!ErrorHandler.Succeeded (this.serviceProvider
 				.GetService<SVsSolution, IVsSolution> ()
-				.GetProjectOfUniqueName (from.ContainingProject.UniqueName, out project)))
+				.GetProjectOfUniqueName (from.ContainingProject.GetUniqueNameOrFullName(), out project)))
 				return null;
 
 			var fileName = from.FileNames[0];

--- a/src/Clide/Clide.csproj
+++ b/src/Clide/Clide.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Extensions\System\Collections\Generic\IEnumerable\Traverser.cs" />
     <Compile Include="Extensions\System\TypeInheritance.cs" />
     <Compile Include="Extensions\System\TypeInheritanceExtension.cs" />
+    <Compile Include="Extensions\VisualStudio\DteExtensions.cs" />
     <Compile Include="Extensions\VisualStudio\IVsHierarchyItemExtensions.cs" />
     <Compile Include="Extensions\VisualStudio\IVsSolutionExtensions.cs" />
     <Compile Include="Interop\BooleanSymbolExpressionEvaluator.cs" />

--- a/src/Clide/Extensions/VisualStudio/DteExtensions.cs
+++ b/src/Clide/Extensions/VisualStudio/DteExtensions.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using EnvDTE;
+
+namespace Clide
+{
+	static class DteExtensions
+	{
+		/// <summary>
+		/// Returns the <see cref="Project.UniqueName"/> or its <see cref="Project.FullName"/> if 
+		/// the first fails.
+		/// </summary>
+		public static string GetUniqueNameOrFullName(this Project project)
+		{
+			try
+			{
+				// This might throw if the project isn't loaded yet.
+				return project.UniqueName;
+			}
+			catch (Exception)
+			{
+				// As a fallback, in C#/VB, the UniqueName == FullName.
+				// It may still fail in the ext call though, but we do our best
+				return project.FullName;
+			}
+		}
+	}
+}


### PR DESCRIPTION
This is consistent with the way C# and VB project systems provide their
UniqueName, but we keep the DTE property retrieval in case other project
systems do it differently.