### PR TITLE
Dump MEF log when VS is started with /log switch

### DIFF
--- a/src/Clide.nuspec
+++ b/src/Clide.nuspec
@@ -101,6 +101,7 @@ v1.0
     <file src="Clide\bin\$configuration$\Clide.dll" target="lib\net45" />
     <file src="Clide\bin\$configuration$\Clide.pdb" target="lib\net45" />
     <file src="Clide\bin\$configuration$\Clide.xml" target="lib\net45" />
+    <file src="Clide\bin\$configuration$\Microsoft.ComponentModel.Composition.Diagnostics.dll" target="lib\net45" />
     <file src="Clide\bin\$configuration$\GitInfo.txt" target="src\" />
     <file src="Clide.Standalone.sln" target="src\Clide.sln" />
     <file src="Clide.props" target="src\" />

--- a/src/Clide/Clide.csproj
+++ b/src/Clide/Clide.csproj
@@ -42,6 +42,9 @@
       <HintPath>..\packages\VSSDK.DTE.9.9.0.4\lib\net20\envdte90a.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.ComponentModel.Composition.Diagnostics">
+      <HintPath>..\..\lib\Microsoft.ComponentModel.Composition.Diagnostics.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.ComponentModelHost, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\VSSDK.ComponentModelHost.11.0.4\lib\net45\Microsoft.VisualStudio.ComponentModelHost.dll</HintPath>
       <Private>True</Private>


### PR DESCRIPTION
This makes it far easier to diagnose composition errors.

When launching with `devenv /log`, upon constructing the MEF container
for a DevEnv for a given package/service provider, a Clide.[PACKAGEGUID].log
will be written to %LocalAppData%\Microsoft\VisualStudio\[VSVERSION][HIVE]\ComponentModelCache.