### PR TITLE
Fixed ProjectsVisitor to avoid throwing an exception for generic nodes

### DIFF
--- a/src/Clide.Interfaces/Solution/ISolutionNodeExtensions.cs
+++ b/src/Clide.Interfaces/Solution/ISolutionNodeExtensions.cs
@@ -85,55 +85,25 @@ public static class ISolutionNodeExtensions
 
 		public bool VisitLeave (IProjectNode project) => true;
 
-		public bool VisitEnter (IFolderNode folder)
-		{
-			throw new NotSupportedException ();
-		}
+		public bool VisitEnter (IFolderNode folder) => false;
 
-		public bool VisitLeave (IFolderNode folder)
-		{
-			throw new NotSupportedException ();
-		}
+		public bool VisitLeave (IFolderNode folder) => false;
 
-		public bool VisitEnter (IItemNode item)
-		{
-			throw new NotSupportedException ();
-		}
+		public bool VisitEnter (IItemNode item) => false;
 
-		public bool VisitLeave (IItemNode item)
-		{
-			throw new NotSupportedException ();
-		}
+		public bool VisitLeave (IItemNode item) => false;
 
-		public bool VisitEnter (IReferencesNode references)
-		{
-			throw new NotSupportedException ();
-		}
+		public bool VisitEnter (IReferencesNode references) => false;
 
-		public bool VisitLeave (IReferencesNode references)
-		{
-			throw new NotSupportedException ();
-		}
+		public bool VisitLeave (IReferencesNode references) => false;
 
-		public bool VisitEnter (IReferenceNode reference)
-		{
-			throw new NotSupportedException ();
-		}
+		public bool VisitEnter (IReferenceNode reference) => false;
 
-		public bool VisitLeave (IReferenceNode reference)
-		{
-			throw new NotSupportedException ();
-		}
+		public bool VisitLeave (IReferenceNode reference) => false;
 
-		public bool VisitEnter (IGenericNode node)
-		{
-			throw new NotImplementedException ();
-		}
+		public bool VisitEnter (IGenericNode node) => false;
 
-		public bool VisitLeave (IGenericNode node)
-		{
-			throw new NotImplementedException ();
-		}
+		public bool VisitLeave (IGenericNode node) => false;
 	}
 
 	class FilteringProjectsVisitor : ISolutionVisitor


### PR DESCRIPTION
Returning false when we want to stop visiting nodes instead of throwing
an NotImplementedException.

When a project is unloaded in a solution, the IGenericNode is visited.
With the previous implementation we were throwing an exception instead
of just stopping the node visiting at the moment.

There is no advantage of throwing when the node is not supposed to
be visited. We just need to stop continue visiting the children at
that moment.