### PR TITLE
Fixed VsHierarchyItemManagerProvider to use AsyncLazy<T> instead of L…

### DIFF
--- a/src/Clide/Components/Interop/VsHierarchyItemManagerProvider.cs
+++ b/src/Clide/Components/Interop/VsHierarchyItemManagerProvider.cs
@@ -1,26 +1,28 @@
 ﻿using System;
 using System.ComponentModel.Composition;
-using Merq;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
 
 namespace Clide.Components.Interop
 {
-	[PartCreationPolicy(CreationPolicy.Shared)]
-	internal class VsHierarchyItemManagerProvider
-	{
-		Lazy<IVsHierarchyItemManager> hierarchyManager;
+    [PartCreationPolicy(CreationPolicy.Shared)]
+    internal class VsHierarchyItemManagerProvider
+    {
+        readonly AsyncLazy<IVsHierarchyItemManager> hierarchyManager;
 
-		[ImportingConstructor]
-		public VsHierarchyItemManagerProvider ([Import (typeof (SVsServiceProvider))] IServiceProvider services, IAsyncManager async)
-		{
-			hierarchyManager = new Lazy<IVsHierarchyItemManager> (() => async.Run (async () => {
-				await async.SwitchToMainThread ();
-				return services.GetService<SComponentModel, IComponentModel> ().GetService<IVsHierarchyItemManager> ();
-			}));
-		}
+        [ImportingConstructor]
+        public VsHierarchyItemManagerProvider([Import(typeof(SVsServiceProvider))] IServiceProvider services)
+        {
+            hierarchyManager = new AsyncLazy<IVsHierarchyItemManager>(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-		[Export(ContractNames.Interop.IVsHierarchyItemManager)]
-		public IVsHierarchyItemManager HierarchyManager => hierarchyManager.Value;
-	}
+                return services.GetService<SComponentModel, IComponentModel>().GetService<IVsHierarchyItemManager>();
+            }, ThreadHelper.JoinableTaskFactory);
+        }
+
+        [Export(ContractNames.Interop.IVsHierarchyItemManager)]
+        public IVsHierarchyItemManager HierarchyManager => ThreadHelper.JoinableTaskFactory.Run(async () => await hierarchyManager.GetValueAsync());
+    }
 }


### PR DESCRIPTION
…azy<T>

Using Lazy<T> with a value factory that makes UI thread switching or use the JoinableTaskContext to do synchronous blocking is considered a threading anti pattern given that it can lead to deadlocks.
For the case of the VsHierarchyItemManagerProvider, we are doing the two things. First, using JoinableTaskFactory to do a synchronous block in order to allow switching to the UI thread inside.

There is already a threading analyzer that warns if this pattern is violated, and explains the different situations: https://github.com/Microsoft/vs-threading/blob/master/doc/analyzers/VSTHRD011.md
This problem has been found after deeply analyzing the logs and dumps of a VS Feedback issue with serious locks in VS when opening Xamarin iOS solutions. This is the feedback issue: https://developercommunity.visualstudio.com/content/problem/289617/opening-xamarin-ios-solution-locks-vs-2017-hard.html

This pattern should be fixed properly for Dev16, together with a complete async patterns review, in all the places and not only in this class and repo, but for d15.9 we are only including this fix to limit the impact.