### PR TITLE
Fixed VsHierarchyItemManagerProvider to use AsyncLazy<T> instead of L…

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -70,6 +70,10 @@
 	</Target>
 
 	<Target Name="Test">
+		<MSBuild Projects="src\Clide.UnitTests\Clide.UnitTests.csproj" BuildInParallel="false" Targets="GetTargetPath" Properties="$(CommonBuildProperties)">
+			<Output TaskParameter="TargetOutputs" ItemName="TestAssembly" />
+		</MSBuild>
+
 		<xunit Assemblies="@(TestAssembly)" />
 	</Target>
 

--- a/src/Clide/Components/Interop/VsHierarchyItemManagerProvider.cs
+++ b/src/Clide/Components/Interop/VsHierarchyItemManagerProvider.cs
@@ -1,26 +1,32 @@
-﻿using System;
-using System.ComponentModel.Composition;
-using Merq;
+﻿using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
+using IAsyncServiceProvider = Microsoft.VisualStudio.Shell.IAsyncServiceProvider;
 
 namespace Clide.Components.Interop
 {
-	[PartCreationPolicy(CreationPolicy.Shared)]
+    [PartCreationPolicy(CreationPolicy.Shared)]
 	internal class VsHierarchyItemManagerProvider
 	{
-		Lazy<IVsHierarchyItemManager> hierarchyManager;
+        readonly JoinableTaskContext context;
+		readonly AsyncLazy<IVsHierarchyItemManager> hierarchyManager;
 
 		[ImportingConstructor]
-		public VsHierarchyItemManagerProvider ([Import (typeof (SVsServiceProvider))] IServiceProvider services, IAsyncManager async)
+		public VsHierarchyItemManagerProvider ([Import (typeof (SAsyncServiceProvider))] IAsyncServiceProvider services, JoinableTaskContext context)
 		{
-			hierarchyManager = new Lazy<IVsHierarchyItemManager> (() => async.Run (async () => {
-				await async.SwitchToMainThread ();
-				return services.GetService<SComponentModel, IComponentModel> ().GetService<IVsHierarchyItemManager> ();
-			}));
+            this.context = context;
+			hierarchyManager = new AsyncLazy<IVsHierarchyItemManager> (async () => {
+                await context.Factory.SwitchToMainThreadAsync();
+
+                var componentModel = await services.GetServiceAsync(typeof(SComponentModel)) as IComponentModel;
+
+                return componentModel.GetService<IVsHierarchyItemManager>();
+            }, context.Factory);
 		}
 
 		[Export(ContractNames.Interop.IVsHierarchyItemManager)]
-		public IVsHierarchyItemManager HierarchyManager => hierarchyManager.Value;
-	}
+		public IVsHierarchyItemManager HierarchyManager => context.Factory.Run (async () => await hierarchyManager.GetValueAsync ());
+    }
 }


### PR DESCRIPTION
…azy<T>

Using Lazy<T> with a value factory that makes UI thread switching or use the JoinableTaskContext to do synchronous blocking is considered a threading anti pattern given that it can lead to deadlocks.
For the case of the VsHierarchyItemManagerProvider, we are doing the two things. First, using JoinableTaskFactory to do a synchronous block in order to allow switching to the UI thread inside.

There is already a threading analyzer that warns if this pattern is violated, and explains the different situations: https://github.com/Microsoft/vs-threading/blob/master/doc/analyzers/VSTHRD011.md
This problem has been found after deeply analyzing the logs and dumps of a VS Feedback issue with serious locks in VS when opening Xamarin iOS solutions. This is the feedback issue: https://developercommunity.visualstudio.com/content/problem/289617/opening-xamarin-ios-solution-locks-vs-2017-hard.html

This pattern should be fixed properly for Dev16, together with a complete async patterns review, in all the places and not only in this class and repo, but for d15.9 we are only including this fix to limit the impact.