### PR TITLE
Added Startable support

### DIFF
--- a/src/Clide.Interfaces/Startable/IStartable.cs
+++ b/src/Clide.Interfaces/Startable/IStartable.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Clide
+{
+    /// <summary>
+    /// Represents a component that needs to be started by the <see cref="IStartableService"/>
+    /// </summary>
+    public interface IStartable
+    {
+        /// <summary>
+        /// Runs the startup logic for the component
+        /// </summary>
+        Task StartAsync();
+    }
+}

--- a/src/Clide.Interfaces/Startable/IStartableService.cs
+++ b/src/Clide.Interfaces/Startable/IStartableService.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Clide
+{
+    /// <summary>
+    /// Service that allows to start components that matches a given context
+    /// </summary>
+    public interface IStartableService
+    {
+        /// <summary>
+        /// Starts all the components that matches the given context
+        /// </summary>
+        /// <param name="context">The context string to filter the components that need to be started</param>
+        /// <returns></returns>
+        Task StartComponentsAsync(string context);
+
+        /// <summary>
+        /// Starts all the components that matches the given context
+        /// </summary>
+        /// <param name="context">The context string to filter the components that need to be started</param>
+        /// <param name="cancellationToken">The token to cancel the ongoing work</param>
+        /// <returns></returns>
+        Task StartComponentsAsync(string context, CancellationToken cancellationToken);
+    }
+}

--- a/src/Clide.Interfaces/Startable/StartableAttribute.cs
+++ b/src/Clide.Interfaces/Startable/StartableAttribute.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.ComponentModel.Composition;
+
+namespace Clide
+{
+    /// <summary>
+    /// Provides the metadata attriute to export a component that needs to be started
+    /// </summary>
+    [MetadataAttribute]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    public class StartableAttribute : ExportAttribute
+    {
+        /// <summary>
+        /// Creates an instance of <see cref="StartableAttribute"/>
+        /// </summary>
+        /// <param name="context">
+        /// Specifies the context when the component should be started.
+        /// The value can be a Guid string which it will be automatically parsed into <see cref="StartableAttribute.ContextGuid"/>
+        /// </param>
+        public StartableAttribute(string context)
+            : base(typeof(IStartable))
+        {
+            Context = context;
+
+            Guid guid;
+            if (Guid.TryParse(context, out guid))
+                ContextGuid = guid;
+        }
+
+        /// <summary>
+        /// Gets the context when the component should be started
+        /// </summary>
+        public string Context { get; }
+
+        /// <summary>
+        /// Gets the context as a Guid if it could be parsed
+        /// </summary>
+        public Guid ContextGuid { get; }
+    }
+}

--- a/src/Clide.UnitTests/StartableServiceSpec.cs
+++ b/src/Clide.UnitTests/StartableServiceSpec.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.ComponentModel.Composition.Hosting;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ComponentModelHost;
+using Moq;
+using Xunit;
+
+namespace Clide
+{
+    public class StartableServiceSpec
+    {
+        [Fact]
+        public void when_starting_components_with_matching_case_insensitive_context_string_then_components_are_started()
+        {
+            var foo = new Mock<IStartable>();
+            var bar = new Mock<IStartable>();
+
+            var service = new StartableService(
+                new[]
+                {
+                    new Lazy<IStartable, IStartableMetadata>
+                    (
+                        () => foo.Object,
+                        Mock.Of<IStartableMetadata>(x => x.Context == "solutionLoaded")
+                    ),
+                    new Lazy<IStartable, IStartableMetadata>
+                    (
+                        () => bar.Object,
+                        Mock.Of<IStartableMetadata>(x => x.Context == "SolutionLoaded")
+                    )
+                });
+
+            service.StartComponentsAsync("solutionLoaded").Wait();
+
+            foo.Verify(x => x.StartAsync());
+            bar.Verify(x => x.StartAsync());
+        }
+
+        [Fact]
+        public void when_starting_components_with_non_matching_context_string_then_components_are_not_started()
+        {
+            var foo = new Mock<IStartable>();
+
+            var service = new StartableService(
+                new[]
+                {
+                    new Lazy<IStartable, IStartableMetadata>
+                    (
+                        () => foo.Object,
+                        Mock.Of<IStartableMetadata>(x => x.Context == "solutionLoaded")
+                    )
+                });
+
+            service.StartComponentsAsync("packageLoaded").Wait();
+
+            foo.Verify(x => x.StartAsync(), Times.Never);
+        }
+
+        [Fact]
+        public void when_starting_components_with_context_guid_then_components_are_started()
+        {
+            var contextGuid = Guid.NewGuid();
+
+            var foo = new Mock<IStartable>();
+            var bar = new Mock<IStartable>();
+
+            var service = new StartableService(
+                new[]
+                {
+                        new Lazy<IStartable, IStartableMetadata>
+                        (
+                            () => foo.Object,
+                            Mock.Of<IStartableMetadata>(x => x.ContextGuid == contextGuid)
+                        ),
+                        new Lazy<IStartable, IStartableMetadata>
+                        (
+                            () => bar.Object,
+                            Mock.Of<IStartableMetadata>(x => x.ContextGuid == Guid.NewGuid())
+                        )
+                });
+
+            service.StartComponentsAsync(contextGuid.ToString().ToLowerInvariant()).Wait();
+
+            foo.Verify(x => x.StartAsync());
+            bar.Verify(x => x.StartAsync(), Times.Never());
+        }
+
+        [Fact]
+        public void when_first_component_cancels_task_then_second_component_is_not_started()
+        {
+            var cts = new CancellationTokenSource();
+
+            var firtComponent = new CancellationComponent(cts);
+            var secondComponent = new Mock<IStartable>();
+
+            var service = new StartableService(
+                new[]
+                {
+                    new Lazy<IStartable, IStartableMetadata>
+                    (
+                        () => firtComponent,
+                        Mock.Of<IStartableMetadata>(x => x.Context == "solutionLoaded")
+                    ),
+                    new Lazy<IStartable, IStartableMetadata>
+                    (
+                        () => secondComponent.Object,
+                        Mock.Of<IStartableMetadata>(x => x.Context == "solutionLoaded")
+                    )
+                });
+
+            service.StartComponentsAsync("solutionLoaded", cts.Token).Wait();
+
+            Assert.True(cts.IsCancellationRequested);
+            secondComponent.Verify(x => x.StartAsync(), Times.Never);
+        }
+
+        class CancellationComponent : IStartable
+        {
+            readonly CancellationTokenSource cts;
+
+            public CancellationComponent(CancellationTokenSource cts)
+            {
+                this.cts = cts;
+            }
+
+            public Task StartAsync()
+            {
+                cts.Cancel();
+
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/src/Clide/Startable/IStartableMetadata.cs
+++ b/src/Clide/Startable/IStartableMetadata.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Clide
+{
+    public interface IStartableMetadata
+    {
+        string Context { get; }
+
+        Guid ContextGuid { get; }
+    }
+}

--- a/src/Clide/Startable/StartableService.cs
+++ b/src/Clide/Startable/StartableService.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Clide
+{
+    [Export(typeof(IStartableService))]
+    [PartCreationPolicy(CreationPolicy.Shared)]
+    class StartableService : IStartableService
+    {
+        readonly IEnumerable<Lazy<IStartable, IStartableMetadata>> components;
+
+        [ImportingConstructor]
+        public StartableService([ImportMany] IEnumerable<Lazy<IStartable, IStartableMetadata>> components)
+        {
+            this.components = components;
+        }
+
+        public Task StartComponentsAsync(string context) =>
+            StartComponentsAsync(context, CancellationToken.None);
+
+        public async Task StartComponentsAsync(string context, CancellationToken cancellationToken)
+        {
+            if (!Guid.TryParse(context, out var contextGuid))
+                contextGuid = Guid.Empty;
+
+            var componentsToBeStarted = components
+                .Where(x =>
+                    string.Equals(x.Metadata.Context, context, StringComparison.OrdinalIgnoreCase) ||
+                    (contextGuid != Guid.Empty && x.Metadata.ContextGuid == contextGuid));
+
+            foreach (var component in componentsToBeStarted)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                    return;
+
+                await component.Value.StartAsync();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Which allows a client to start components that matches a given context (string or Guid)
using the IStartableService and exporting the components using the Startable attribute.