### PR TITLE
Allow properties to be declared to be awaitable

### DIFF
--- a/src/Clide.Interfaces/Awaitable.cs
+++ b/src/Clide.Interfaces/Awaitable.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.ComponentModel;
+using System.Threading.Tasks;
+
+namespace Clide
+{
+    /// <summary>
+    /// Provides a factory for <see cref="Awaitable{T}"/>.
+    /// </summary>
+    public static class Awaitable
+    {
+        /// <summary>
+        /// Creates an <see cref="Awaitable{T}"/> for the given getter.
+        /// </summary>
+        public static Awaitable<T> Create<T>(Func<Task<T>> getter) => new Awaitable<T>(getter);
+    }
+
+    /// <summary>
+    /// Allows retrieving a property value by awaiting it,
+    /// instead of turning such properties into <c>GetXXXAsync</c> 
+    /// methods all over the place.
+    /// </summary>
+    public sealed class Awaitable<T>
+    {
+        Func<Task<T>> getter;
+
+        /// <summary>
+        /// Creates the awaitable value with a getter that retrieves the 
+        /// task to calculate the value.
+        /// </summary>
+        public Awaitable(Func<Task<T>> getter) => this.getter = getter;
+
+        /// <summary>
+        /// <c>await</c> the value instead of invoking this method.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public System.Runtime.CompilerServices.TaskAwaiter<T> GetAwaiter() => getter.Invoke().GetAwaiter();
+
+        /// <summary>
+        /// See <see cref="object.Equals(object)"/>.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj) => base.Equals(obj);
+
+        /// <summary>
+        /// See <see cref="object.GetHashCode"/>.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode() => base.GetHashCode();
+
+        /// <summary>
+        /// See <see cref="object.ToString"/>.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override string ToString() => base.ToString();
+    }
+}


### PR DESCRIPTION
Instead of turning every async property into an GetXXXAsync
method, create instead a special-purpose class that prevents
doing the `.Result` anti-pattern and instead makes it trivial
to just `await Property` so that the API remains idiomatic.

We may expose analyzers that can hint at what awaitable
properties should run on the UI thread, for example.