### PR TITLE
Added IProjectNode -> IVsBuildPropertyStorage adapter

### DIFF
--- a/src/Clide.Interfaces/Adapters/SolutionAdapterFacade.cs
+++ b/src/Clide.Interfaces/Adapters/SolutionAdapterFacade.cs
@@ -149,6 +149,12 @@ public static partial class Adapters
     /// <returns>The <see cref="IVsProject"/> or <see langword="null"/> if conversion is not possible.</returns>
     public static IVsProject AsVsProject(this IProjectNode project) => project.As<IVsProject>();
 
+    /// <summary>
+    /// Adapts a <see cref="IProjectNode"/> to an <see cref="IVsBuildPropertyStorage"/>.
+    /// </summary>
+    /// <returns>The <see cref="IVsBuildPropertyStorage"/> or <see langword="null"/> if conversion is not possible.</returns>
+    public static IVsBuildPropertyStorage AsVsBuildPropertyStorage(this IProjectNode project) => project.As<IVsBuildPropertyStorage>();
+
     #endregion
 
     #region VSLang

--- a/src/Clide.Interfaces/Adapters/VsAdapterFacade.cs
+++ b/src/Clide.Interfaces/Adapters/VsAdapterFacade.cs
@@ -7,6 +7,8 @@ public static partial class AdapterFacade
     /// Adapts a <see cref="IVsHierarchy"/> to an <see cref="IProjectNode"/>.
     /// </summary>
     /// <returns>The <see cref="IProjectNode"/> or <see langword="null"/> if conversion is not possible.</returns>
-    public static IProjectNode AsProjectNode(this IVsHierarchy project) =>
-        project.GetServiceLocator().GetExport<IAdapterService>().Adapt(project).As<IProjectNode>();
+    public static IProjectNode AsProjectNode(this IVsHierarchy project, IVsHierarchy innerHierarchy = null) =>
+        innerHierarchy == null ?
+            project.GetServiceLocator().GetExport<IAdapterService>().Adapt(project).As<IProjectNode>() :
+            project.GetServiceLocator().GetExport<IAdapterService>().Adapt(new FlavoredProject(project, innerHierarchy)).As<IProjectNode>();
 }

--- a/src/Clide.Interfaces/FlavoredProject.cs
+++ b/src/Clide.Interfaces/FlavoredProject.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Clide
+{
+    class FlavoredProject
+    {
+        public FlavoredProject(IVsHierarchy hierarchy, IVsHierarchy innerHierarchy)
+        {
+            Hierarchy = hierarchy;
+            InnerHierarchy = innerHierarchy;
+        }
+
+        public IVsHierarchy Hierarchy { get; }
+
+        public IVsHierarchy InnerHierarchy { get; }
+    }
+}

--- a/src/Clide.Vsix/Clide.Vsix.csproj
+++ b/src/Clide.Vsix/Clide.Vsix.csproj
@@ -11,6 +11,8 @@
     <IsProductComponent>true</IsProductComponent>
     <BypassVsixValidation Condition="'$(CI)' == 'true'">true</BypassVsixValidation>
 
+    <CreateVsixContainer>true</CreateVsixContainer>
+    
     <Experimental>true</Experimental>
     <Experimental Condition="'$(CI)' == 'true'">false</Experimental>
     <SystemComponent>false</SystemComponent>

--- a/src/Clide/Adapters/SolutionToVsAdapter.cs
+++ b/src/Clide/Adapters/SolutionToVsAdapter.cs
@@ -8,7 +8,8 @@ namespace Clide
         IAdapter<SolutionExplorerNode, IVsHierarchyItem>,
         IAdapter<SolutionExplorerNode, IVsHierarchy>,
         IAdapter<SolutionNode, IVsSolution>,
-        IAdapter<ProjectNode, IVsProject>
+        IAdapter<ProjectNode, IVsProject>,
+        IAdapter<ProjectNode, IVsBuildPropertyStorage>
     {
         IVsHierarchyItem IAdapter<SolutionExplorerNode, IVsHierarchyItem>.Adapt(SolutionExplorerNode from) => from?.HierarchyNode;
 
@@ -17,5 +18,9 @@ namespace Clide
         IVsSolution IAdapter<SolutionNode, IVsSolution>.Adapt(SolutionNode from) => from.HierarchyNode.GetServiceProvider().GetService<SVsSolution, IVsSolution>();
 
         IVsProject IAdapter<ProjectNode, IVsProject>.Adapt(ProjectNode from) => from.HierarchyNode.GetActualHierarchy() as IVsProject;
+
+        IVsBuildPropertyStorage IAdapter<ProjectNode, IVsBuildPropertyStorage>.Adapt(ProjectNode from) => 
+            from.InnerHierarchyNode?.GetActualHierarchy() as IVsBuildPropertyStorage ?? 
+                from.HierarchyNode.GetActualHierarchy() as IVsBuildPropertyStorage;
     }
 }

--- a/src/Clide/Adapters/VsToSolutionAdapter.cs
+++ b/src/Clide/Adapters/VsToSolutionAdapter.cs
@@ -9,7 +9,8 @@ namespace Clide
 
     [Adapter]
     internal class VsToSolutionAdapter :
-        IAdapter<IVsHierarchy, IProjectNode>
+        IAdapter<IVsHierarchy, IProjectNode>,
+        IAdapter<FlavoredProject, IProjectNode>
     {
         readonly Lazy<ISolutionExplorerNodeFactory> nodeFactory;
         readonly JoinableLazy<IVsHierarchyItemManager> hierarchyItemManager;
@@ -28,5 +29,11 @@ namespace Clide
                 .Value
                 .CreateNode(hierarchyItemManager.GetValue().GetHierarchyItem(from, VSConstants.VSITEMID_ROOT))
                 as IProjectNode;
+
+        public IProjectNode Adapt(FlavoredProject from) =>
+            (nodeFactory
+                .Value
+                .CreateNode(hierarchyItemManager.GetValue().GetHierarchyItem(from.Hierarchy, VSConstants.VSITEMID_ROOT))
+                as ProjectNode).WithInnerHierarchy(hierarchyItemManager.GetValue().GetHierarchyItem(from.InnerHierarchy, VSConstants.VSITEMID_ROOT));
     }
 }

--- a/src/Clide/Solution/ConfigProjectProperties.cs
+++ b/src/Clide/Solution/ConfigProjectProperties.cs
@@ -22,7 +22,7 @@ namespace Clide
         {
             this.project = project;
             this.configName = configName;
-            vsBuild = project.AsVsHierarchy() as IVsBuildPropertyStorage;
+            vsBuild = project.AsVsBuildPropertyStorage();
             if (vsBuild == null)
                 tracer.Warn(Strings.ConfigProjectProperties.NonMsBuildProject(project.Text));
 

--- a/src/Clide/Solution/ConfigUserProjectProperties.cs
+++ b/src/Clide/Solution/ConfigUserProjectProperties.cs
@@ -22,7 +22,7 @@ namespace Clide
         {
             this.project = project;
             this.configName = configName;
-            vsBuild = project.AsVsHierarchy() as IVsBuildPropertyStorage;
+            vsBuild = project.AsVsBuildPropertyStorage();
             if (vsBuild == null)
                 tracer.Warn(Strings.ConfigUserProjectProperties.NonMsBuildProject(project.Text, configName));
 

--- a/src/Clide/Solution/GlobalProjectProperties.cs
+++ b/src/Clide/Solution/GlobalProjectProperties.cs
@@ -19,7 +19,7 @@ namespace Clide
         {
             msBuildProject = project.As<Project>();
             dteProject = project.As<EnvDTE.Project>();
-            vsBuild = project.AsVsHierarchy() as IVsBuildPropertyStorage;
+            vsBuild = project.AsVsBuildPropertyStorage();
             accessor = new DynamicPropertyAccessor(this);
         }
 

--- a/src/Clide/Solution/ItemProperties.cs
+++ b/src/Clide/Solution/ItemProperties.cs
@@ -23,7 +23,7 @@ namespace Clide
         {
             this.item = item.HierarchyNode.GetExtenderObject() as ProjectItem;
             node = item.HierarchyNode;
-            msBuild = item.HierarchyNode.GetRoot().HierarchyIdentity.Hierarchy as IVsBuildPropertyStorage;
+            msBuild = item.OwningProject.AsVsBuildPropertyStorage();
         }
 
         public override IEnumerable<string> GetDynamicMemberNames() => GetPropertyNames();

--- a/src/Clide/Solution/ProjectNode.cs
+++ b/src/Clide/Solution/ProjectNode.cs
@@ -13,6 +13,7 @@ namespace Clide
     public class ProjectNode : SolutionExplorerNode, IProjectNode
     {
         Lazy<GlobalProjectProperties> properties;
+        IVsHierarchyItem innerHierarchyItem;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ProjectNode"/> class.
@@ -25,13 +26,20 @@ namespace Clide
             ISolutionExplorerNodeFactory nodeFactory,
             IAdapterService adapter,
             JoinableLazy<IVsUIHierarchyWindow> solutionExplorer,
-            JoinableLazy<IVsBooleanSymbolExpressionEvaluator> expressionEvaluator)
+            JoinableLazy<IVsBooleanSymbolExpressionEvaluator> expressionEvaluator,
+            IVsHierarchyItem innerHierarchyNode = null)
             : base(SolutionNodeKind.Project, hierarchyNode, nodeFactory, adapter, solutionExplorer)
         {
+            this.innerHierarchyItem = innerHierarchyNode;
             properties = new Lazy<GlobalProjectProperties>(() => new GlobalProjectProperties(this));
             ExpressionEvaluator = expressionEvaluator;
             Configuration = new ProjectConfiguration(new Lazy<EnvDTE.Project>(() => As<EnvDTE.Project>()));
         }
+
+        public IProjectNode WithInnerHierarchy(IVsHierarchyItem innerHierarchyItem) =>
+            new ProjectNode(hierarchyItem, nodeFactory, adapter, solutionExplorer, ExpressionEvaluator, innerHierarchyItem);
+
+        public IVsHierarchyItem InnerHierarchyNode => innerHierarchyItem;
 
         JoinableLazy<IVsBooleanSymbolExpressionEvaluator> ExpressionEvaluator { get; }
 

--- a/src/Clide/Solution/SolutionExplorerNode.cs
+++ b/src/Clide/Solution/SolutionExplorerNode.cs
@@ -17,11 +17,11 @@ namespace Clide
     [DebuggerDisplay("{Name} ({Kind})")]
     public abstract class SolutionExplorerNode : ISolutionExplorerNode
     {
-        IVsHierarchyItem hierarchyItem;
-        ISolutionExplorerNodeFactory nodeFactory;
-        IAdapterService adapter;
+        protected IVsHierarchyItem hierarchyItem;
+        protected ISolutionExplorerNodeFactory nodeFactory;
+        protected IAdapterService adapter;
 
-        JoinableLazy<IVsUIHierarchyWindow> solutionExplorer;
+        protected JoinableLazy<IVsUIHierarchyWindow> solutionExplorer;
         Lazy<ISolutionExplorerNode> parent;
         Lazy<string> name;
         Lazy<bool> isHidden;

--- a/src/Clide/Solution/UserProjectProperties.cs
+++ b/src/Clide/Solution/UserProjectProperties.cs
@@ -24,7 +24,7 @@ namespace Clide
             this.project = project;
             msBuildProject = project.AsMsBuildProject();
             dteProject = project.As<EnvDTE.Project>();
-            vsBuild = project.AsVsHierarchy() as IVsBuildPropertyStorage;
+            vsBuild = project.AsVsBuildPropertyStorage();
 
             if (msBuildProject == null || vsBuild == null)
                 tracer.Warn(Strings.UserProjectProperties.NonMsBuildProject(project.Text));


### PR DESCRIPTION
Supporting also the case where the ProjectNode was adapted from a
flavored project where the InnerVsHierarchy should be used
to cast the IVsHierarchy to IVsBuildPropertyStorage