### PR TITLE
Allowing to use multiple instance of StartableAttribute

### DIFF
--- a/src/Clide.Interfaces/Startable/StartableAttribute.cs
+++ b/src/Clide.Interfaces/Startable/StartableAttribute.cs
@@ -7,7 +7,7 @@ namespace Clide
     /// Provides the metadata attriute to export a component that needs to be started
     /// </summary>
     [MetadataAttribute]
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
     public class StartableAttribute : ExportAttribute
     {
         /// <summary>


### PR DESCRIPTION
Some components might need to be started when any of the provided context are enabled.
So allowing multiple instances of the attribute unblocks this scenario:

[Startable("OnSolutionLoaded")]
[Startable("OnSettingsLoaded")]
public class MyComponent : IStartable {}