### PR TITLE
Added support to define more than one startable context

### DIFF
--- a/src/Clide.Interfaces/Startable/StartableAttribute.cs
+++ b/src/Clide.Interfaces/Startable/StartableAttribute.cs
@@ -7,7 +7,7 @@ namespace Clide
     /// Provides the metadata attriute to export a component that needs to be started
     /// </summary>
     [MetadataAttribute]
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
     public class StartableAttribute : ExportAttribute
     {
         /// <summary>

--- a/src/Clide.Interfaces/Startable/StartableAttribute.cs
+++ b/src/Clide.Interfaces/Startable/StartableAttribute.cs
@@ -4,7 +4,7 @@ using System.ComponentModel.Composition;
 namespace Clide
 {
     /// <summary>
-    /// Provides the metadata attriute to export a component that needs to be started
+    /// Provides the metadata attribute to export a component that needs to be started
     /// </summary>
     [MetadataAttribute]
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
@@ -24,21 +24,13 @@ namespace Clide
             : base(typeof(IStartable))
         {
             Context = context;
-
-            Guid guid;
-            if (Guid.TryParse(context, out guid))
-                ContextGuid = guid;
         }
 
         /// <summary>
         /// Gets the context when the component should be started
+        /// The string can also contains multiple values separated by '|'
         /// </summary>
         public string Context { get; }
-
-        /// <summary>
-        /// Gets the context as a Guid if it could be parsed
-        /// </summary>
-        public Guid ContextGuid { get; }
 
         /// <summary>
         /// Gets the order value for the startable component

--- a/src/Clide/Startable/IStartableMetadata.cs
+++ b/src/Clide/Startable/IStartableMetadata.cs
@@ -6,8 +6,6 @@ namespace Clide
     {
         string Context { get; }
 
-        Guid ContextGuid { get; }
-
         double Order { get; }
     }
 }


### PR DESCRIPTION
The context string can now contains multiple values separated by "|". e.g.

[Startable("OnSolutionLoad|{FFADDAAF-C12A-4426-B0E9-533A7AE8B27E}"]

It can also contains mixed string and guid values.
So the given startable component will be started when any of the following
IStartableService invocations occur:

startableService.StartComponentsAsync("OnSolutionLoad")
or
startableService.StartComponentsAsync("{FFADDAAF-C12A-4426-B0E9-533A7AE8B27E}")