### PR TITLE
Properly convert IVsHierchy to IVsProject

### DIFF
--- a/src/Clide/Solution/ItemNode.cs
+++ b/src/Clide/Solution/ItemNode.cs
@@ -41,7 +41,7 @@ namespace Clide
         {
             get
             {
-                var project = HierarchyNode.GetActualHierarchy() as IVsProject;
+                var project = OwningProject.AsVsProject();
                 string filePath;
                 if (project != null && ErrorHandler.Succeeded(project.GetMkDocument(HierarchyNode.GetActualItemId(), out filePath)) &&
                     File.Exists(filePath))


### PR DESCRIPTION
This fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/718419
Previously in dev16 the IVsHierarchy -> IVsProject cast returned null, at least
for a MonoAndroidFlavoredProject.