### PR TITLE
Added support to avoid Executing commands based on a given UI Context

### DIFF
--- a/src/Clide.Interfaces/Commands/CommandAttribute.cs
+++ b/src/Clide.Interfaces/Commands/CommandAttribute.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel.Composition;
 
 namespace Clide
@@ -8,18 +7,46 @@ namespace Clide
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
     public class CommandAttribute : ExportAttribute
     {
-        public CommandAttribute(string packageGuid, string groupGuid, int commandId)
+        /// <summary>
+        /// Creates an instance of <see cref="CommandAttribute"/>
+        /// </summary>
+        /// <param name="packageGuid">The Package Guid</param>
+        /// <param name="groupGuid">The CommandSet Guid</param>
+        /// <param name="commandId">The Command ID</param>
+        /// <param name="visibilityContextGuid">
+        /// Gets the associated UI Context guid.
+        /// When the UI Context is not active, the QueryStatus or Execute method won't be invoked at all.
+        /// And the command will be disabled and invisible.
+        /// </param>
+        public CommandAttribute(string packageGuid, string groupGuid, int commandId, string visibilityContextGuid = null)
             : base(typeof(ICommandExtension))
         {
             PackageId = packageGuid;
             GroupId = groupGuid;
             CommandId = commandId;
+            VisibilityContextGuid = visibilityContextGuid;
         }
 
+        /// <summary>
+        /// Gets the Package Guid
+        /// </summary>
         public string PackageId { get; }
 
+        /// <summary>
+        /// Gets the CommandSet Guid
+        /// </summary>
         public string GroupId { get; }
 
+        /// <summary>
+        /// Gets the Command ID
+        /// </summary>
         public int CommandId { get; }
+
+        /// <summary>
+        /// Gets the associated UI Context guid.
+        /// When the UI Context is not active, the QueryStatus or Execute method won't be invoked at all.
+        /// And the command will be disabled and invisible.
+        /// </summary>
+        public string VisibilityContextGuid { get; }
     }
 }

--- a/src/Clide.UnitTests/VsCommandExtensionAdapterSpec .cs
+++ b/src/Clide.UnitTests/VsCommandExtensionAdapterSpec .cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using Moq;
+using Clide.Commands;
+using Xunit;
+using System.ComponentModel.Design;
+
+namespace Clide
+{
+    public class VsCommandExtensionAdapterSpec
+    {
+        static readonly CommandID TestCommandID = new CommandID(Guid.Empty, 1);
+
+        [Fact]
+        public void when_uicontext_is_active_then_query_status_is_called()
+        {
+            var command = new Mock<ICommandExtension>();
+
+            var adapter = new VsCommandExtensionAdapter(TestCommandID, command.Object, new UIContextWrapper(true), true);
+
+            command.Verify(x => x.QueryStatus(It.IsAny<IMenuCommand>()), Times.Once);
+        }
+
+        [Fact]
+        public void when_uicontext_is_not_active_then_query_status_is_not_called()
+        {
+            var command = new Mock<ICommandExtension>();
+
+            var adapter = new VsCommandExtensionAdapter(TestCommandID, command.Object, new UIContextWrapper(false), true);
+
+            command.Verify(x => x.QueryStatus(It.IsAny<IMenuCommand>()), Times.Never);
+        }
+
+        [Fact]
+        public void when_uicontext_is_not_active_then_adapter_is_disabled_and_invisible()
+        {
+            var command = new Mock<ICommandExtension>();
+
+            var adapter = new VsCommandExtensionAdapter(TestCommandID, command.Object, new UIContextWrapper(false), true);
+
+            Assert.False(adapter.Enabled);
+            Assert.False(adapter.Visible);
+        }
+
+        [Fact]
+        public void when_uicontext_is_active_then_command_is_executed()
+        {
+            var command = new Mock<ICommandExtension>();
+
+            var adapter = new VsCommandExtensionAdapter(TestCommandID, command.Object, new UIContextWrapper(true));
+
+            adapter.Invoke();
+
+            command.Verify(x => x.Execute(It.IsAny<IMenuCommand>()), Times.Once);
+        }
+
+        [Fact]
+        public void when_uicontext_is_not_active_then_command_is_not_executed()
+        {
+            var command = new Mock<ICommandExtension>();
+
+            var adapter = new VsCommandExtensionAdapter(TestCommandID, command.Object, new UIContextWrapper(false));
+            adapter.Invoke();
+
+            command.Verify(x => x.Execute(It.IsAny<IMenuCommand>()), Times.Never);
+        }
+
+        [Fact]
+        public void when_command_is_not_enabled_then_command_is_not_executed()
+        {
+            var command = new Mock<ICommandExtension>();
+            // Disable the command by implementing the QueryStatus
+            command
+                .Setup(x => x.QueryStatus(It.IsAny<IMenuCommand>()))
+                .Callback<IMenuCommand>(x =>
+                {
+                    x.Enabled = false;
+                    x.Visible = false;
+                });
+
+            var adapter = new VsCommandExtensionAdapter(TestCommandID, command.Object);
+            adapter.Invoke();
+
+            // Ensure the QueryStatus is executed when the command is executed
+            command.Verify(x => x.QueryStatus(It.IsAny<IMenuCommand>()), Times.AtLeastOnce());
+            // Ensure the command is not executed based on the QueryStatus disable logic
+            command.Verify(x => x.Execute(It.IsAny<IMenuCommand>()), Times.Never);
+        }
+    }
+}

--- a/src/Clide/Commands/CommandRegistrar.cs
+++ b/src/Clide/Commands/CommandRegistrar.cs
@@ -6,6 +6,7 @@ using System.ComponentModel.Design;
 using System.Diagnostics;
 using System.Linq;
 using Clide.Properties;
+using Microsoft.VisualStudio.Shell;
 
 namespace Clide.Commands
 {
@@ -58,11 +59,17 @@ namespace Clide.Commands
 
             List<Lazy<ICommandExtension, ICommandMetadata>> commands;
             if (commandsByPackage.Value.TryGetValue(packageGuid, out commands))
+            {
                 foreach (var command in commands)
+                {
                     menuCommandService.AddCommand(
                         new VsCommandExtensionAdapter(
                             new CommandID(new Guid(command.Metadata.GroupId), command.Metadata.CommandId),
-                            command.Value));
+                            command.Value,
+                            Guid.TryParse(command.Metadata.VisibilityContextGuid, out var uiContextGuid) ? 
+                                new UIContextWrapper(UIContext.FromUIContextGuid(uiContextGuid)) : null));
+                }
+            }
         }
     }
 }

--- a/src/Clide/Commands/ICommandMetadata.cs
+++ b/src/Clide/Commands/ICommandMetadata.cs
@@ -21,5 +21,10 @@ namespace Clide.Commands
         /// Gets the command id
         /// </summary>
         int CommandId { get; }
+
+        /// <summary>
+        /// Gets the UI Context Guid that should be active when the command is executed
+        /// </summary>
+        string VisibilityContextGuid { get; }
     }
 }

--- a/src/Clide/Commands/UIContextWrapper.cs
+++ b/src/Clide/Commands/UIContextWrapper.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Microsoft.VisualStudio.Shell;
+
+namespace Clide.Commands
+{
+    /// <summary>
+    /// Wrapper for <see cref="Microsoft.VisualStudio.Shell.UIContext"/> in order to be used in unit tests
+    /// </summary>
+    class UIContextWrapper
+    {
+        readonly bool isActive;
+        readonly UIContext vsUIContext;
+
+        public UIContextWrapper(UIContext vsUIContext)
+        {
+            this.vsUIContext = vsUIContext;
+        }
+
+        public UIContextWrapper(bool isActive)
+        {
+            this.isActive = isActive;
+        }
+
+        public bool IsActive => vsUIContext?.IsActive ?? isActive;
+    }
+}

--- a/src/Clide/Commands/VsCommandExtensionAdapter.cs
+++ b/src/Clide/Commands/VsCommandExtensionAdapter.cs
@@ -11,21 +11,30 @@ namespace Clide.Commands
     /// automatically shielding it for errors to avoid VS hangs, and starting an activity before 
     /// executing it.
     /// </summary>
-    public class VsCommandExtensionAdapter : OleMenuCommand
+    class VsCommandExtensionAdapter : OleMenuCommand
     {
         private readonly ITracer tracer;
+        private readonly UIContextWrapper uiContext;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="VsCommandExtensionAdapter"/> class with a 
         /// specific command identifier and implementation.
         /// </summary>
-        public VsCommandExtensionAdapter(CommandID id, ICommandExtension implementation)
+        public VsCommandExtensionAdapter(
+            CommandID id, 
+            ICommandExtension implementation, 
+            UIContextWrapper uiContext = null,
+            bool triggerQueryStatus = false /* for testing purposes only */)
             : base(OnExecute, id)
         {
             tracer = Tracer.Get(this.GetType());
 
             this.Implementation = implementation;
+            this.uiContext = uiContext;
             this.BeforeQueryStatus += this.OnBeforeQueryStatus;
+
+            if (triggerQueryStatus)
+                OnBeforeQueryStatus(this, new EventArgs());
         }
 
         /// <summary>
@@ -36,25 +45,28 @@ namespace Clide.Commands
         private static void OnExecute(object sender, EventArgs e)
         {
             var command = (VsCommandExtensionAdapter)sender;
-            var menu = new MenuCommand { Enabled = command.Enabled, Text = command.Text, Visible = command.Visible };
-
-            using (command.tracer.StartActivity(Strings.VsCommandExtensionAdapter.ExecutingCommand(
-                command.Text, command.Implementation.GetType().Name)))
+            if (command.uiContext?.IsActive ?? true)
             {
-                command.tracer.ShieldUI(() =>
-                {
-                    command.Implementation.QueryStatus(menu);
+                var menu = new MenuCommand { Enabled = command.Enabled, Text = command.Text, Visible = command.Visible };
 
-                    if (menu.Enabled)
+                using (command.tracer.StartActivity(Strings.VsCommandExtensionAdapter.ExecutingCommand(
+                    command.Text, command.Implementation.GetType().Name)))
+                {
+                    command.tracer.ShieldUI(() =>
                     {
-                        command.Implementation.Execute(menu);
-                    }
-                    else
-                    {
-                        command.tracer.Warn(Strings.VsCommandExtensionAdapter.CannotExecute(
-                            menu.Text, command.Implementation.GetType().Name));
-                    }
-                }, Strings.VsCommandExtensionAdapter.ExecuteShieldMessage);
+                        command.Implementation.QueryStatus(menu);
+
+                        if (menu.Enabled)
+                        {
+                            command.Implementation.Execute(menu);
+                        }
+                        else
+                        {
+                            command.tracer.Warn(Strings.VsCommandExtensionAdapter.CannotExecute(
+                                menu.Text, command.Implementation.GetType().Name));
+                        }
+                    }, Strings.VsCommandExtensionAdapter.ExecuteShieldMessage);
+                }
             }
         }
 
@@ -63,25 +75,41 @@ namespace Clide.Commands
             var command = (VsCommandExtensionAdapter)sender;
             // Preventively set to false.
             command.Enabled = false;
-            var menu = new MenuCommand
-            {
-                Enabled = command.Enabled,
-                Text = command.Implementation.Text,
-                Visible = command.Visible
-            };
 
-            try
+            var isContextActive = command.uiContext?.IsActive ?? true;
+
+            if (!isContextActive && command.uiContext != null)
+                command.Visible = false;
+
+            if (isContextActive)
             {
-                command.Implementation.QueryStatus(menu);
-                command.Enabled = menu.Enabled;
-                command.Visible = menu.Visible;
-                command.Text = menu.Text;
-                command.Checked = menu.Checked;
+                var menu = new MenuCommand
+                {
+                    Enabled = command.Enabled,
+                    Text = command.Implementation.Text,
+                    Visible = command.Visible
+                };
+
+                try
+                {
+                    command.Implementation.QueryStatus(menu);
+                    command.Enabled = menu.Enabled;
+                    command.Visible = menu.Visible;
+                    command.Text = menu.Text;
+                    command.Checked = menu.Checked;
+                }
+                catch (Exception ex)
+                {
+                    command.Enabled = command.Visible = false;
+                    command.tracer.Error(ex, Strings.VsCommandExtensionAdapter.QueryStatusShieldMessage);
+                }
             }
-            catch (Exception ex)
+            else if (command.uiContext != null)
             {
-                command.Enabled = command.Visible = false;
-                command.tracer.Error(ex, Strings.VsCommandExtensionAdapter.QueryStatusShieldMessage);
+                // If the user opted-in to disable the command when the context is not active
+                // we should also set Visible=false
+                // We're only doing this when UIContext != null to be backward compatible with the previous behavior
+                command.Visible = false;
             }
         }
 


### PR DESCRIPTION
Added an extra and optional argument to the CommandAttribute to define
the associated UI Context that should be active for the command
to be executed.

When the UI Context is not active neither the QueryStatus or the Execute
should be executed. And also the command should be disabled and invisible.