### PR TITLE
Fixes ProjectNode Save method

### DIFF
--- a/src/Clide/Solution/ProjectNode.cs
+++ b/src/Clide/Solution/ProjectNode.cs
@@ -50,12 +50,14 @@ namespace Clide
         /// </summary>
         public virtual void Save()
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             ErrorHandler.ThrowOnFailure(HierarchyNode
                 .GetServiceProvider()
                 .GetService<SVsSolution, IVsSolution>()
                 .SaveSolutionElement(
                     (uint)__VSSLNSAVEOPTIONS.SLNSAVEOPT_ForceSave,
-                    HierarchyNode.HierarchyIdentity.Hierarchy,
+                    innerHierarchyItem != null ? innerHierarchyItem.GetActualHierarchy() : HierarchyNode.GetActualHierarchy(),
                     0));
         }
 


### PR DESCRIPTION
- We should use the InnerHierarchy, if available, in case the ProjectNode represents the Flavored Hierarchy, because the later isn't the "real" Hierarchy and will make the Save fail.
- Added ThrowIfNotOnUIThread to ensure callers are running on the main thread since accessing the IVSSolution should only be done on that one.