### PR TITLE
Fixed creation of project nodes for flavored projects

### DIFF
--- a/src/Clide/Adapters/SolutionToVsAdapter.cs
+++ b/src/Clide/Adapters/SolutionToVsAdapter.cs
@@ -13,7 +13,7 @@ namespace Clide
     {
         IVsHierarchyItem IAdapter<SolutionExplorerNode, IVsHierarchyItem>.Adapt(SolutionExplorerNode from) => from?.HierarchyNode;
 
-        IVsHierarchy IAdapter<SolutionExplorerNode, IVsHierarchy>.Adapt(SolutionExplorerNode from) => from?.HierarchyNode.GetActualHierarchy();
+        IVsHierarchy IAdapter<SolutionExplorerNode, IVsHierarchy>.Adapt(SolutionExplorerNode from) => from?.Hierarchy;
 
         IVsSolution IAdapter<SolutionNode, IVsSolution>.Adapt(SolutionNode from) => from.HierarchyNode.GetServiceProvider().GetService<SVsSolution, IVsSolution>();
 
@@ -23,13 +23,10 @@ namespace Clide
 
         T GetVsService<T>(ProjectNode from) where T : class
         {
-            var result = from.InnerHierarchyNode?.GetActualHierarchy() as T;
+            var result = from.Hierarchy as T;
 
             if (result == null)
                 result = from.HierarchyNode.GetActualHierarchy() as T;
-
-            if (result == null && from.HierarchyNode.TryGetInnerHierarchy(out var innerHierarchy))
-                result = innerHierarchy as T;
 
             return result;
         }

--- a/src/Clide/Adapters/VsToSolutionAdapter.cs
+++ b/src/Clide/Adapters/VsToSolutionAdapter.cs
@@ -28,16 +28,18 @@ namespace Clide
         }
 
         public IProjectNode Adapt(IVsHierarchy from) =>
-            nodeFactory
-                .Value
-                .CreateNode(GetHierarchyItem(from))
-                as IProjectNode;
+            from is FlavoredProject && from.TryGetInnerHierarchy(out var innerHierarchy) ?
+                Adapt(new FlavoredProject(from, innerHierarchy)) :
+                nodeFactory
+                    .Value
+                    .CreateNode(GetHierarchyItem(from))
+                    as IProjectNode;
 
         public IProjectNode Adapt(FlavoredProject from) =>
             (nodeFactory
                 .Value
-                .CreateNode(GetHierarchyItem(from.Hierarchy))
-                as ProjectNode).WithInnerHierarchy(GetHierarchyItem(from.InnerHierarchy));
+                .CreateNode(GetHierarchyItem(from.InnerHierarchy))
+                as ProjectNode).WithFlavorHierarchy(from.Hierarchy);
 
         IVsHierarchyItem GetHierarchyItem(IVsHierarchy hierarchy) =>
             asyncManager.Run(async () =>

--- a/src/Clide/Extensions/VisualStudio/IVsHierarchyExtensions.cs
+++ b/src/Clide/Extensions/VisualStudio/IVsHierarchyExtensions.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Microsoft.VisualStudio.Shell.Flavor;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Clide
+{
+    /// <summary>
+    /// Provides extensions for Visual Studio low-level <see cref="IVsHierarchy"/>.
+    /// </summary>
+    internal static class IVsHierarchyExtensions
+    {
+        /// <summary>
+        /// Gets the inner hierarchy of the flavored proejct
+        /// when the actual hierarchy of the item is an instance of <see cref="FlavoredProjectBase"/>
+        /// </summary>
+        public static bool TryGetInnerHierarchy(this IVsHierarchy hierarchy, out IVsHierarchy innerHierarchy)
+        {
+            innerHierarchy = null;
+
+            if (hierarchy is FlavoredProjectBase)
+            {
+                innerHierarchy = hierarchy
+                     .GetType()
+                     .GetField("_innerVsHierarchy", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)?
+                     .GetValue(hierarchy) as IVsHierarchy;
+            }
+
+            return innerHierarchy != null;
+        }
+    }
+}

--- a/src/Clide/Extensions/VisualStudio/IVsHierarchyItemExtensions.cs
+++ b/src/Clide/Extensions/VisualStudio/IVsHierarchyItemExtensions.cs
@@ -23,26 +23,6 @@ namespace Clide
         }
 
         /// <summary>
-        /// Gets the inner hierarchy of the flavored proejct
-        /// when the actual hierarchy of the item is an instance of <see cref="FlavoredProjectBase"/>
-        /// </summary>
-        public static bool TryGetInnerHierarchy(this IVsHierarchyItem item, out IVsHierarchy innerHierarchy)
-        {
-            innerHierarchy = null;
-
-            var hierarchy = item.GetActualHierarchy();
-            if (hierarchy is FlavoredProjectBase)
-            {
-                innerHierarchy = hierarchy
-                     .GetType()
-                     .GetField("_innerVsHierarchy", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)?
-                     .GetValue(hierarchy) as IVsHierarchy;
-            }
-
-            return innerHierarchy != null;
-        }
-
-        /// <summary>
         /// Gets the actual item id, which is the nested id if the item is nested.
         /// </summary>
         public static uint GetActualItemId(this IVsHierarchyItem item)

--- a/src/Clide/Solution/SolutionExplorerNode.cs
+++ b/src/Clide/Solution/SolutionExplorerNode.cs
@@ -84,6 +84,11 @@ namespace Clide
         protected internal IVsHierarchyItem HierarchyNode => hierarchyItem;
 
         /// <summary>
+        /// Gets the hierarchy represented by this node
+        /// </summary>
+        protected internal virtual IVsHierarchy Hierarchy => hierarchy;
+
+        /// <summary>
         /// Gets the adapter service used to construct this node.
         /// </summary>
         protected IAdapterService Adapter => adapter;


### PR DESCRIPTION
We must not call Get IVsHierarchyItemManager.GetHierarchyItem if the
corresponding IVsHierarchy does not implement IVsProject. For the case
of flavored project it might or it might not be the case. So we should
always use the inner hierarchy and keep the flavored hierarchy instance
for IVsHierarchy.GetProp scenarios where we should able to:

projectNode.AsVsHierarchy().GetProperty(x)

where x is provided by the flavored project so AsVsHierarchy() should
retrieve the flavored instance.