### PR TITLE
Adds ChannelSuffix to DevEnvInfo

### DIFF
--- a/src/Clide.Interfaces/DevEnvInfo.cs
+++ b/src/Clide.Interfaces/DevEnvInfo.cs
@@ -20,6 +20,11 @@ namespace Clide
         public string ChannelTitle { get; internal set; }
 
         /// <summary>
+        /// Gets the Visual Studio channel suffix
+        /// </summary>
+        public string ChannelSuffix { get; internal set; }
+
+        /// <summary>
         /// Gets the Visual Studio edition
         /// </summary>
         public string Edition { get; internal set; }

--- a/src/Clide/DevEnvInfoProvider.cs
+++ b/src/Clide/DevEnvInfoProvider.cs
@@ -41,6 +41,7 @@ namespace Clide
             {
                 ChannelId = vsAppId.GetProperty<string>(VSAPropID.VSAPROPID_ChannelId),
                 ChannelTitle = vsAppId.GetProperty<string>(VSAPropID.VSAPROPID_ChannelTitle),
+                ChannelSuffix = vsAppId.GetProperty<string>(VSAPropID.VSAPROPID_ChannelSuffix),
                 Edition = vsAppId.GetProperty<string>(VSAPropID.VSAPROPID_SKUName),
                 InstallationID = vsAppId.GetProperty<string>(VSAPropID.VSAPROPID_IsolationInstallationId),
                 InstallationName = vsAppId.GetProperty<string>(VSAPropID.VSAPROPID_IsolationInstallationName),

--- a/src/Clide/Interop/IVsAppId.cs
+++ b/src/Clide/Interop/IVsAppId.cs
@@ -35,6 +35,7 @@ namespace Microsoft.VisualStudio.Shell
         VSAPROPID_ChannelId = -8638,
         VSAPROPID_ProductDisplayVersion = -8641,
         VSAPROPID_ChannelTitle = -8643,
+        VSAPROPID_ChannelSuffix = -8644,
         VSAPROPID_SKUName = -8648,
     }
 


### PR DESCRIPTION
This information is needed to differentiate Release Candidate from Release versions, both ChannelTitle will be "Release", but the ChannelSuffix for the candidate one will be "RC".