### PR TITLE
Remove unnecessary SVsAppId

### DIFF
--- a/src/Clide.IntegrationTests/AsyncManagerSpec.cs
+++ b/src/Clide.IntegrationTests/AsyncManagerSpec.cs
@@ -1,6 +1,5 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
-using Merq;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Threading;
 using Xunit;

--- a/src/Clide.IntegrationTests/DevEnvInfoProviderSpec.cs
+++ b/src/Clide.IntegrationTests/DevEnvInfoProviderSpec.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.VisualStudio.ComponentModelHost;
+using Xunit;
+
+namespace Clide
+{
+    public class DevEnvInfoProviderSpec
+    {
+        [VsixFact]
+        public void when_getting_device_info_then_can_get_app_id()
+        {
+            var info = GlobalServices.GetService<SComponentModel, IComponentModel>().GetService<DevEnvInfo>();
+
+            Assert.NotNull(info);
+            Assert.NotEmpty(info.ChannelId);
+            Assert.NotEmpty(info.ChannelSuffix);
+            Assert.NotEmpty(info.ChannelTitle);
+        }
+    }
+}

--- a/src/Clide.IntegrationTests/Misc.cs
+++ b/src/Clide.IntegrationTests/Misc.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using EnvDTE;
 using EnvDTE80;
-using Merq;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Shell;

--- a/src/Clide/DevEnvInfoProvider.cs
+++ b/src/Clide/DevEnvInfoProvider.cs
@@ -27,7 +27,7 @@ namespace Clide
 
         DevEnvInfo GetDevEnvInfo(IServiceLocator serviceLocator)
         {
-            var vsAppId = serviceLocator.TryGetService<SVsAppId, IVsAppId>();
+            var vsAppId = serviceLocator.TryGetService<IVsAppId>();
 
             if (vsAppId == null)
                 return null;

--- a/src/Clide/Interop/IVsAppId.cs
+++ b/src/Clide/Interop/IVsAppId.cs
@@ -3,11 +3,6 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.VisualStudio.Shell
 {
-    [Guid("1EAA526A-0898-11d3-B868-00C04F79F802"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    internal interface SVsAppId
-    {
-    }
-
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("1EAA526A-0898-11d3-B868-00C04F79F802")]
     internal interface IVsAppId
     {


### PR DESCRIPTION
In some cases, the SVs/IVs pattern is used to assign a service id (The SVs interface’s GUID) that differs from the ids of any interfaces it may happen to implement. Some times, it is just aliased to be the same id.

In this second case, declaring a dummy type with the same Guid is *not* needed, and it can moreover cause issues in the CLR as two COM types will end up having the same ID.

In service queries the only thing that matters is the GUIDs not the type, so for the purposes of GetService the types given are just a place to hang a GUID.

This commit removes the SVsAppId and replaces it with IVsAppId when queried.