### PR TITLE
Using FlavoredProjectBase to check if we should use the IVsHierarchy

### DIFF
--- a/src/Clide/Adapters/VsToSolutionAdapter.cs
+++ b/src/Clide/Adapters/VsToSolutionAdapter.cs
@@ -28,7 +28,7 @@ namespace Clide
         }
 
         public IProjectNode Adapt(IVsHierarchy from) =>
-            from is FlavoredProject && from.TryGetInnerHierarchy(out var innerHierarchy) ?
+            from is FlavoredProjectBase && from.TryGetInnerHierarchy(out var innerHierarchy) ?
                 Adapt(new FlavoredProject(from, innerHierarchy)) :
                 nodeFactory
                     .Value

--- a/src/Clide/Adapters/VsToSolutionAdapter.cs
+++ b/src/Clide/Adapters/VsToSolutionAdapter.cs
@@ -1,5 +1,6 @@
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Flavor;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
 using System;


### PR DESCRIPTION
We must not call Get IVsHierarchyItemManager.GetHierarchyItem if the
corresponding IVsHierarchy is the flavored instance.

This commit fixes the base type we should have used to detect this case.