### PR TITLE
Ensure OwningSolution value by switching to IVsSolution usage

### DIFF
--- a/src/Clide/Solution/SolutionExplorerNode.cs
+++ b/src/Clide/Solution/SolutionExplorerNode.cs
@@ -64,7 +64,8 @@ namespace Clide
                 new Lazy<bool>(() => getHiddenProperty() || parent.Value.IsHidden) :
                 new Lazy<bool>(() => getHiddenProperty());
 
-            solutionNode = new JoinableLazy<ISolutionNode>(() => this.nodeFactory.CreateNode(this.hierarchyItem.GetTopMost()) as ISolutionNode, true);
+            solutionNode = new JoinableLazy<ISolutionNode>(async () =>
+                await ServiceLocator.Global.GetExport<ISolutionExplorer>().Solution);
 
             if (hierarchyItem.HierarchyIdentity.IsNestedItem)
             {


### PR DESCRIPTION
Before we were looking for the top most hierarchy item which in some
scenarios (project just loaded or debugging) was not working.

So we switch to ask the SolutionNode to the ISolutionExplorer which
already has an implementation using IVsSolution.