### PR TITLE
Fixed usage of IVsHierarchyItem.Children in ReferencesNodeFactory

### DIFF
--- a/src/Clide/Solution/Factories/ReferencesNodeFactory.cs
+++ b/src/Clide/Solution/Factories/ReferencesNodeFactory.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
 
 namespace Clide
 {
@@ -12,31 +13,50 @@ namespace Clide
         Lazy<ISolutionExplorerNodeFactory> childNodeFactory;
         IAdapterService adapter;
         JoinableLazy<IVsUIHierarchyWindow> solutionExplorer;
+        JoinableTaskFactory asyncManager;
 
         [ImportingConstructor]
         public ReferencesNodeFactory(
             Lazy<ISolutionExplorerNodeFactory> childNodeFactory,
             IAdapterService adapter,
-            JoinableLazy<IVsUIHierarchyWindow> solutionExplorer)
+            JoinableLazy<IVsUIHierarchyWindow> solutionExplorer,
+            JoinableTaskContext jtc)
         {
             this.childNodeFactory = childNodeFactory;
             this.adapter = adapter;
             this.solutionExplorer = solutionExplorer;
+            this.asyncManager = jtc.Factory;
         }
 
         public virtual bool Supports(IVsHierarchyItem item)
         {
+            var result = false;
+
             // For performance reasons we're first checking if the
             // extender object is null which it's expected for
-            // the ReferencesNode.
-            //
-            // Then we check for the 1033 localized Text string or finally
-            // the first child to be a VSLangProj.Reference
-            return item.GetExtenderObject() == null &&
-                (
-                    item.Text == "References" ||
-                    item.Children.FirstOrDefault()?.GetExtenderObject() is VSLangProj.Reference
-                );
+            // the ReferencesNode
+            if (item.GetExtenderObject() == null && item.Parent?.GetExtenderObject() is EnvDTE.Project)
+            {
+                // Then we first check for the localized Text string 
+                result = item.Text == "References" || item.Text == "Referencias";
+
+                if (!result)
+                {
+                    // Or first if any child is an instance of VSLangProj.Reference
+                    // It's important to call .Children to avoid ending up with duplicate
+                    // element when Children are still not created
+                    // And also we need to use Any because the first item might be
+                    // a PackageReference which does not provide an extender object
+                    result = asyncManager.Run(async () =>
+                    {
+                        await asyncManager.SwitchToMainThreadAsync();
+
+                        return item.Children.Any(x => x.GetExtenderObject() is VSLangProj.Reference);
+                    });
+                }
+            }
+
+            return result;
         }
 
         public virtual ISolutionExplorerNode CreateNode(IVsHierarchyItem item) => Supports(item) ?


### PR DESCRIPTION
This complements commit https://github.com/clariuslabs/clide/commit/422c15ce01b4817fab402dc4b3be3d103136ec9a

In order to avoid the creation of duplicate children we need to switch to the main
thread before calling IVsHierarchyItem.Children

And we also switched to use Any because the first item might be a PackageReference
which it does not provide an extender object.