### PR TITLE
Fixed the Nodes traversal

### DIFF
--- a/src/Clide.Extensibility/Solution/ISolutionExplorerNodeFactory.cs
+++ b/src/Clide.Extensibility/Solution/ISolutionExplorerNodeFactory.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Clide
 {
@@ -12,5 +13,10 @@ namespace Clide
         /// Creates the node for the given hierarchy item.
         /// </summary>
         ISolutionExplorerNode CreateNode(IVsHierarchyItem item);
+
+        /// <summary>
+        /// Creates the node for the given hierarchy
+        /// </summary>
+        ISolutionExplorerNode CreateNode(IVsHierarchy hierarchy, uint itemId);
     }
 }


### PR DESCRIPTION
The HierarchyManager was not implemented to be thread safe.
If the Nodes are being traversed from a background thread,
the caller might end up with a duplicate key/item exception.

So the proposal fix is to replace the existing implementation
by traversing the hierarchy using the legacy FirstChild/NextSibling
mechanism and switch to the main thread only when we need to
get/create the HierarchyItem.