### PR TITLE
Avoiding to switch to MainThread if not necessary

### DIFF
--- a/src/Clide.Extensibility/Solution/ISolutionExplorerNodeFactory.cs
+++ b/src/Clide.Extensibility/Solution/ISolutionExplorerNodeFactory.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.Shell;
+﻿using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Clide
@@ -17,6 +18,6 @@ namespace Clide
         /// <summary>
         /// Creates the node for the given hierarchy
         /// </summary>
-        ISolutionExplorerNode CreateNode(IVsHierarchy hierarchy, uint itemId);
+        ISolutionExplorerNode CreateNode(IVsHierarchy hierarchy, uint itemId = VSConstants.VSITEMID_ROOT);
     }
 }

--- a/src/Clide/Solution/Factories/SolutionExplorerNodeFactory.cs
+++ b/src/Clide/Solution/Factories/SolutionExplorerNodeFactory.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
+using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
@@ -54,7 +55,7 @@ namespace Clide
             return factory == null ? new GenericNode(item, this, adapter, solutionExplorer) : factory.CreateNode(item);
         }
 
-        public ISolutionExplorerNode CreateNode(IVsHierarchy hierarchy, uint itemId) =>
+        public ISolutionExplorerNode CreateNode(IVsHierarchy hierarchy, uint itemId = VSConstants.VSITEMID_ROOT) =>
             CreateNode(asyncManager.Run(async () =>
             {
                 // TryGetHierarchyItem won't trigger the creation of the HierachyItem


### PR DESCRIPTION
When traversing nodes (or project nodes) we should first check if the
hierarchy item is already created before calling GetHierarchyItem which
requires to run in the main thread.

We achieve this by using ISolutionExplorerNodeFactory.CreateNode and passing
the IVsHierarchy as it was described in the following change:

https://github.com/clariuslabs/clide/commit/b90b856b199d99ea4891b6148cc6e563fbe45974

Fixes https://github.com/clariuslabs/clide/issues/141