### PR TITLE
Pushing DialogCreated event when a dialog is created

### DIFF
--- a/src/Clide.Interfaces/DialogCreated.cs
+++ b/src/Clide.Interfaces/DialogCreated.cs
@@ -1,0 +1,12 @@
+﻿namespace Clide
+{
+    public class DialogCreated
+    {
+        public DialogCreated(IDialogWindow dialog)
+        {
+            Dialog = dialog;
+        }
+
+        public IDialogWindow Dialog { get; }
+    }
+}

--- a/src/Clide/UI/DialogWindowFactory.cs
+++ b/src/Clide/UI/DialogWindowFactory.cs
@@ -18,14 +18,17 @@ namespace Clide
     class DialogWindowFactory : IDialogWindowFactory
     {
         readonly JoinableLazy<IVsUIShell> uiShell;
+        readonly IEventStream eventStream;
         readonly JoinableTaskFactory jtf;
 
         [ImportingConstructor]
         public DialogWindowFactory(
             JoinableLazy<IVsUIShell> uiShell,
-            JoinableTaskContext context)
+            JoinableTaskContext context,
+            IEventStream eventStream)
         {
             this.uiShell = uiShell;
+            this.eventStream = eventStream;
             jtf = context.Factory;
         }
 
@@ -52,6 +55,8 @@ namespace Clide
                     dialogWindow.WindowStartupLocation = WindowStartupLocation.CenterScreen;
                     dialogWindow.ShowInTaskbar = false;
                 });
+
+                eventStream.Push(new DialogCreated(dialog));
             }
 
             return dialog;


### PR DESCRIPTION
This will allow client to be notified when dialog instances
are created and execute and do proper stuff such as logging or
telemetry.