### PR TITLE
Rooted project path when comparing to find configuration context

### DIFF
--- a/src/Clide/Solution/ProjectConfiguration.cs
+++ b/src/Clide/Solution/ProjectConfiguration.cs
@@ -61,7 +61,8 @@ namespace Clide
                 foreach (EnvDTE.SolutionContext context in solution.SolutionBuild.ActiveConfiguration.SolutionContexts)
                 {
                     string projectName = context.ProjectName;
-                    if (projectPath.EndsWith(projectName))
+                    projectName = System.IO.Path.GetFullPath(System.IO.Path.Combine(System.IO.Path.GetDirectoryName(solution.FullName), projectName));
+                    if (string.Equals(projectName, projectPath, StringComparison.InvariantCultureIgnoreCase))
                     {
                         return context.ShouldDeploy;
                     }
@@ -83,7 +84,8 @@ namespace Clide
                 foreach (EnvDTE.SolutionContext context in solution.SolutionBuild.ActiveConfiguration.SolutionContexts)
                 {
                     string projectName = context.ProjectName;
-                    if (projectPath.EndsWith(projectName))
+                    projectName = System.IO.Path.GetFullPath(System.IO.Path.Combine(System.IO.Path.GetDirectoryName(solution.FullName), projectName));
+                    if (string.Equals(projectName, projectPath, StringComparison.InvariantCultureIgnoreCase))
                     {
                         return context.ShouldBuild;
                     }


### PR DESCRIPTION
When comparing configuration context, the project full name is compared with the context's project name.
The problem is that the project in the context is a path relative to the solution, and the project full name is a rooted path.
The solution to that issue was to do EndsWith(), so we can see if the part of the path that the context name represents matches the rooted path. This will generally work, except when the project is not in the tree of the soltuion.
When the project is outside the solution, you may have values like this:
projectName = ..\App1\App1\App1.csproj
project.FullName = C:\Users\joaqu\source\repos\App70\App70\App70.csproj
The fix is to get the solution full name (which includes the path) and combine it with the context name.
I tested this with projects in the solution path, outside of the solution path and in different drives. In cases where projectName is rooted (for instance, when the project is in a different drive) Path.Combine will always use the second parameter if it's rooted.