### PR TITLE
Automatically log binary logs for Xamarin when /log requested

### DIFF
--- a/src/Clide.UnitTests/Clide.UnitTests.csproj
+++ b/src/Clide.UnitTests/Clide.UnitTests.csproj
@@ -5,6 +5,10 @@
     <IncludeVSSDK>true</IncludeVSSDK>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\Clide\Interop\IVsFeatureFlags.cs" Link="Interop\IVsFeatureFlags.cs" />
+    <Compile Include="..\Clide\Interop\SVsFeatureFlags.cs" Link="Interop\SVsFeatureFlags.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="Microsoft.Build" />
     <Reference Include="Microsoft.CSharp" />
@@ -14,5 +18,8 @@
     <ProjectReference Include="..\Clide.Extensibility\Clide.Extensibility.csproj" />
     <ProjectReference Include="..\Clide.Interfaces\Clide.Interfaces.csproj" />
     <ProjectReference Include="..\Clide\Clide.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Interop\" />
   </ItemGroup>
 </Project>

--- a/src/Clide.UnitTests/CompositionSpec.cs
+++ b/src/Clide.UnitTests/CompositionSpec.cs
@@ -4,10 +4,10 @@ using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
 using System.Linq;
 using System.Reactive.Linq;
-using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
 using Merq;
+using Microsoft.Internal.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.ComponentModelHost;
+using Microsoft.VisualStudio.ProjectSystem;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
@@ -120,6 +120,7 @@ namespace Clide
                    new Mock<SVsShellMonitorSelection>()
                        .As<IVsMonitorSelection>().Object &&
                x.GetService(typeof(SVsShell)) == vsShell.Object &&
+               x.GetService(typeof(SVsFeatureFlags)) == Mock.Of<IVsFeatureFlags>() && 
                x.GetService(typeof(SVsUIShell)) ==
                    new Mock<SVsUIShell>()
                        .As<IVsUIShell>().Object
@@ -188,6 +189,13 @@ namespace Clide
 
         [Export]
         public ExportProvider Exports { get { return exports; } }
+    }
+
+    [PartCreationPolicy(CreationPolicy.Shared)]
+    public class CpsProvider
+    {
+        [Export]
+        public UnconfiguredProject UnconfiguredProject { get; } = Mock.Of<UnconfiguredProject>();
     }
 
     public class MockCommandBusProvider

--- a/src/Clide.Vsix/Clide.Vsix.csproj
+++ b/src/Clide.Vsix/Clide.Vsix.csproj
@@ -35,8 +35,8 @@
   <ItemGroup>
     <None Include="source.extension.vsixmanifest" />
     <PackageFile Include="build\*.*" Kind="Build" />
-    <PackageFile Include="MSBuilder.VsixInstaller" Version="1.0.4" Kind="Dependency" />
-    <BindingRedirect Include="Clide" From="3.0.0.0" To="99.9.9.9" />
+    <PackageFile Include="MSBuilder.VsixInstaller" Version="1.0.4" Kind="Dependency" Visible="false" />
+    <BindingRedirect Include="Clide" From="3.0.0.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -60,7 +60,7 @@
       <PackageFile Include="$(TargetVsixContainer)" Kind="Tools" />
     </ItemGroup>
   </Target>
-
+  
   <Target Name="IncludeSymbolsFromProjectReferences" BeforeTargets="GetVsixSourceItems">
     <!-- For any project references that are set to copy local ('Private' property != false), add the output groups for project references that are not set -->
     <ItemGroup>
@@ -90,5 +90,4 @@
       <TargetVsixContainer Condition="'$(PackageOutputPath)' == ''">$([System.IO.Path]::Combine('$(OutDir)', '$(TargetVsixContainerName)'))</TargetVsixContainer>
     </PropertyGroup>
   </Target>
-
 </Project>

--- a/src/Clide.Vsix/Clide.Vsix.csproj
+++ b/src/Clide.Vsix/Clide.Vsix.csproj
@@ -35,6 +35,8 @@
   <ItemGroup>
     <None Include="source.extension.vsixmanifest" />
     <PackageFile Include="build\*.*" Kind="Build" />
+    <None Remove="FeatureFlags.pkgdef" />
+    <Content Include="FeatureFlags.pkgdef" IncludeInVSIX="true" CopyToOutputDirectory="PreserveNewest" />
     <PackageFile Include="MSBuilder.VsixInstaller" Version="1.0.4" Kind="Dependency" Visible="false" />
     <BindingRedirect Include="Clide" From="3.0.0.0" />
   </ItemGroup>

--- a/src/Clide.Vsix/FeatureFlags.pkgdef
+++ b/src/Clide.Vsix/FeatureFlags.pkgdef
@@ -1,0 +1,5 @@
+﻿[$RootKey$\FeatureFlags\Xamarin\DisableDiagnosticsBinlog]
+"Title"="Disable automatic binlogs collection using /log switch (requires restart)"
+"Description"="Whenever Visual Studio is started with the /log switch, automatic binlog collection happens for Xamarin builds, unless disabled."
+"Value"=dword:00000000
+"PreviewPaneChannels"="*"

--- a/src/Clide.Vsix/Properties/launchSettings.json
+++ b/src/Clide.Vsix/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "Clide.Vsix": {
       "commandName": "Executable",
       "executablePath": "$(VsInstallRoot)\\Common7\\IDE\\devenv.exe",
-      "commandLineArgs": "/rootSuffix $(VSSDKTargetPlatformRegRootSuffix)",
+      "commandLineArgs": "/rootSuffix $(VSSDKTargetPlatformRegRootSuffix) /log",
       "environmentVariables": {
         "xunit.vsix.debug": "false"
       }

--- a/src/Clide.Vsix/source.extension.vsixmanifest
+++ b/src/Clide.Vsix/source.extension.vsixmanifest
@@ -16,5 +16,6 @@
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="Clide" Path="Clide.Core.dll" />
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
     <Asset Type="Microsoft.VisualStudio.VsPackage" Path="BindingRedirects.pkgdef" />
+    <Asset Type="Microsoft.VisualStudio.VsPackage" Path="FeatureFlags.pkgdef" />
   </Assets>
 </PackageManifest>

--- a/src/Clide/DiagnosticsLogProvider.cs
+++ b/src/Clide/DiagnosticsLogProvider.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework;
+using Microsoft.VisualStudio.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Build;
+
+namespace Clide
+{
+    [Export(typeof(IBuildLoggerProviderAsync))]
+    [AppliesTo(".NET + XamarinForms")]
+    internal class DiagnosticsLogProvider : IBuildLoggerProviderAsync
+    {
+        readonly UnconfiguredProject project;
+        readonly DiagnosticsLogging logging;
+
+        [ImportingConstructor]
+        public DiagnosticsLogProvider(UnconfiguredProject project, DiagnosticsLogging logging)
+        {
+            this.project = project;
+            this.logging = logging;
+        }
+
+        public Task<IImmutableSet<ILogger>> GetLoggersAsync(IReadOnlyList<string> targets, IImmutableDictionary<string, string> properties, CancellationToken cancellationToken)
+        {
+            if (!logging.ShouldLog)
+                return Task.FromResult<IImmutableSet<ILogger>>(ImmutableHashSet<ILogger>.Empty);
+
+            return Task.FromResult<IImmutableSet<ILogger>>(ImmutableHashSet<ILogger>.Empty.Add(logging.CreateLogger(project.FullPath)));
+        }
+    }
+}

--- a/src/Clide/DiagnosticsLogging.cs
+++ b/src/Clide/DiagnosticsLogging.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.ComponentModel.Composition;
+using System.IO;
+using System.Linq;
+using EnvDTE;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Logging;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
+
+namespace Clide
+{
+    [Export]
+    [PartCreationPolicy(CreationPolicy.Shared)]
+    internal class DiagnosticsLogging
+    {
+        /// {date_time}.{process}.{project}.binlog
+        /// </summary>
+        const string FileNameFormat = "{0}.{1}.{2}.binlog";
+
+        static readonly string LogsBaseDir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "Xamarin", "Logs");
+
+        static readonly bool shouldLog = (Environment.GetCommandLineArgs() ?? Array.Empty<string>())
+            .Any(x => "/log".Equals(x, StringComparison.OrdinalIgnoreCase));
+
+        readonly JoinableTaskFactory jtf;
+        readonly JoinableTask<string> vsVersion;
+
+        [ImportingConstructor]
+        public DiagnosticsLogging(
+            [Import] JoinableTaskContext jtc,
+            [Import(typeof(SVsServiceProvider))] IServiceProvider serviceProvider)
+        {
+            jtf = jtc.Factory;
+            vsVersion = jtf.RunAsync(async () =>
+            {
+                await jtf.SwitchToMainThreadAsync();
+                return serviceProvider.GetService<DTE>().Version;
+            });
+        }
+
+        public bool ShouldLog => shouldLog;
+
+        public ILogger CreateLogger(string projectPath)
+        {
+            string version = default;
+            if (!vsVersion.IsCompleted)
+                version = jtf.Run(async () => await vsVersion);
+            else
+                version = vsVersion.Task.Result;
+
+            var logFile = Path.Combine(
+                LogsBaseDir,
+                version,
+                string.Format(
+                    FileNameFormat,
+                    DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss"),
+                    System.Diagnostics.Process.GetCurrentProcess().Id,
+                    Path.GetFileNameWithoutExtension(projectPath ?? "")));
+
+            return new BinaryLogger
+            {
+                Parameters = logFile,
+                Verbosity = LoggerVerbosity.Diagnostic,
+                CollectProjectImports = BinaryLogger.ProjectImportsCollectionMode.None
+            };
+        }
+    }
+}

--- a/src/Clide/Interop/IVsFeatureFlags.cs
+++ b/src/Clide/Interop/IVsFeatureFlags.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Internal.VisualStudio.Shell.Interop
+{
+	[ComImport, Guid("AD44B8B9-B646-4B18-8847-150695AEC480"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown), TypeIdentifier]
+	public interface IVsFeatureFlags
+	{
+		[MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
+		bool IsFeatureEnabled([In, MarshalAs(UnmanagedType.LPWStr)] string featureName, [In] bool defaultValue);
+	}
+}

--- a/src/Clide/Interop/SVsFeatureFlags.cs
+++ b/src/Clide/Interop/SVsFeatureFlags.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Internal.VisualStudio.Shell.Interop
+{
+    [ComImport, Guid("78A67F33-22CF-426C-8C90-B6E18FD35E0F"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown), TypeIdentifier]
+	public interface SVsFeatureFlags
+	{
+	}
+}

--- a/src/Clide/LegacyDiagnosticsLogProvider.cs
+++ b/src/Clide/LegacyDiagnosticsLogProvider.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework;
+using Microsoft.VisualStudio.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Build;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.BuildLogging;
+
+namespace Clide
+{
+    [AppliesTo("Managed + (Android | iOS | XamarinXaml)")]
+    [Export("Xamarin.VisualStudio.BuildLoggerProvider", typeof(IVsBuildLoggerProvider))]
+    [PartCreationPolicy(CreationPolicy.Shared)]
+    internal class LegacyDiagnosticsLogProvider : IVsBuildLoggerProvider
+    {
+        static readonly Lazy<BuildLoggerEvents> allEvents = new Lazy<BuildLoggerEvents>(() => Enum
+            .GetValues(typeof(BuildLoggerEvents))
+            .Cast<BuildLoggerEvents>()
+            .Aggregate((BuildLoggerEvents)0, (result, current) => result |= current));
+
+        DiagnosticsLogging logging;
+
+        [ImportingConstructor]
+        public LegacyDiagnosticsLogProvider(DiagnosticsLogging logging) => this.logging = logging;
+
+        public LoggerVerbosity Verbosity => LoggerVerbosity.Diagnostic;
+
+        public BuildLoggerEvents Events => allEvents.Value;
+
+        public ILogger GetLogger(string projectPath, IEnumerable<string> targets, IDictionary<string, string> properties, bool isDesignTimeBuild)
+        {
+            if (!logging.ShouldLog)
+                return null;
+
+            return logging.CreateLogger(projectPath);
+        }
+    }
+}

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -61,7 +61,7 @@
     <XVSSDKBuildToolsVersion Condition="'$(CI)' != 'true'">0.4.0-alpha.*</XVSSDKBuildToolsVersion>
     <XVSSDKBuildToolsVersion Condition="'$(CI)' == 'true'">0.4.0-alpha.9</XVSSDKBuildToolsVersion>
 
-    <VSSDKBuildToolsVersion>15.7.109</VSSDKBuildToolsVersion>
+    <VSSDKBuildToolsVersion>15.8.3252</VSSDKBuildToolsVersion>
 
     <VSSDKAnalyzersVersion>15.8.33</VSSDKAnalyzersVersion>
     <VSThreadingAnalyzersVersion>15.8.132</VSThreadingAnalyzersVersion>


### PR DESCRIPTION
Fixes AB#1025304, https://dev.azure.com/DevDiv/DevDiv/_workitems/edit/1025304

Whenever VS is started with `/log`, collect binary logs so Xamarin can do more
extensive troubleshooting when users provide logs. Applies *only* to Xamarin
projects and NETStandard projects with the `XamarinForms` capability, which
will limit its impact even though starting VS with `/log` is rare and a very
explicit opt-in action by a user.