### PR TITLE
Center the dialog on the owner, rather than the screen

### DIFF
--- a/src/Clide.Core.Windows/UI/DialogWindowFactory.cs
+++ b/src/Clide.Core.Windows/UI/DialogWindowFactory.cs
@@ -52,7 +52,7 @@ namespace Clide
                     await jtf.SwitchToMainThreadAsync();
                     ErrorHandler.ThrowOnFailure(uiShell.GetValue().GetDialogOwnerHwnd(out var owner));
                     new WindowInteropHelper(dialogWindow).Owner = owner;
-                    dialogWindow.WindowStartupLocation = WindowStartupLocation.CenterScreen;
+                    dialogWindow.WindowStartupLocation = WindowStartupLocation.CenterOwner;
                     dialogWindow.ShowInTaskbar = false;
                 });
 


### PR DESCRIPTION
In some rare cases, high DPI and VS might cause dialogs to be centered off-screen. 
To be safe, center on the owner window instead, which is always the visible IDE anyway, 
so it's also more appropriate.