### PR TITLE
Automatically detect the presence of an experimental Clide

### DIFF
--- a/src/Clide.Windows/build/Clide.Windows.targets
+++ b/src/Clide.Windows/build/Clide.Windows.targets
@@ -6,4 +6,26 @@
     </PropertyGroup>
   </Target>
   <Target Name="ClideVsix" Returns="$(ClideVsixPath)" />
+
+  <Target Name="_UseExperimental" AfterTargets="ResolveAssemblyReferences" DependsOnTargets="ResolveAssemblyReferences" Condition="'$(VsInstallRoot)' != '' and '$(UseExperimental)' != 'false'">
+    <PropertyGroup>
+      <DevEnvIniFile>$(VsInstallRoot)\Common7\IDE\devenv.isolation.ini</DevEnvIniFile>
+      <DevEnvIni Condition="Exists($(DevEnvIniFile))">$([System.IO.File]::ReadAllText($(DevEnvIniFile)))</DevEnvIni>
+      <VsInstallationID>$([System.Text.RegularExpressions.Regex]::Match('$(DevEnvIni)', 'InstallationID=(\w+)').Groups[1].Value)</VsInstallationID>
+      <ClideExperimental>$(LOCALAPPDATA)\Microsoft\VisualStudio\$(VisualStudioVersion)_$(VsInstallationID)Exp\Extensions\ClariusLabs\Clide\42.42.42</ClideExperimental>
+    </PropertyGroup>
+
+    <Warning Condition="Exists('$(ClideExperimental)')" Code="CLIDE001" Text="An experimental version of Clide was found at $(ClideExperimental). Replacing references with experimental ones. You can disable this behavior by setting UseExperimental=false." />
+
+    <ItemGroup Condition="Exists('$(ClideExperimental)')">
+      <_ClideReference Include="@(ReferencePath -> WithMetadataValue('NuGetPackageId', 'Clide'))" />
+      <_ClideReference Include="@(ReferencePath -> WithMetadataValue('NuGetPackageId', 'Clide.Windows'))" />
+      <_ClideExperimental Include="@(_ClideReference -> '$(ClideExperimental)\%(Filename)%(Extension)')" />
+      <ReferencePath Remove="@(_ClideReference)" />
+      <ReferencePath Include="@(_ClideExperimental)" />
+    </ItemGroup>
+
+    <Warning Condition="Exists('$(ClideExperimental)') and '@(_ClideExperimental)' != ''" Code="CLIDE001" Text="Replaced %(_ClideExperimental.Filename)%(_ClideExperimental.Extension) with experimental version." />
+  </Target>
+
 </Project>


### PR DESCRIPTION
Whenever Clide is built from source, it will be deployed and enabled in
the experimental instance of VS. Since the install path in the experimental
instance is predictable, we can automatically attempt to find it and offer
a better inner loop for contributors by replacing the nuget-provided Clide
references in their VSIX with the ones deployed by a locally build Clide.

This means contributing and consuming the contribution is as easy as
building Clide and then build as normal your extension. At some point when
the new APIs are available via nuget, you just bump the package reference
and can remove the experimental Clide from the local deploy folder at
`%LocalAppData%\Microsoft\VisualStudio\16.0_[INSTANCEID]Exp\Extensions\ClariusLabs\Clide\42.42.42`.
A quick `devenv /updateConfiguration /rootSuffix Exp` from the developer
command prompt would quickly unregister it and the newly updated/inserted
Clide (from the main VS) will again be the one in use.