### PR TITLE
Adopt versioning guideline for libraries

### DIFF
--- a/src/Clide.Vsix/Clide.Vsix.csproj
+++ b/src/Clide.Vsix/Clide.Vsix.csproj
@@ -71,7 +71,7 @@
   <Target Name="GetVsixVersion" Returns="$(VsixVersion)" DependsOnTargets="SetVersion">
     <PropertyGroup>
       <VsixVersion Condition="'$(Configuration)' == 'Debug'">42.42.42</VsixVersion>
-      <VsixVersion Condition="'$(VsixVersion)' == ''">$(AssemblyVersion)</VsixVersion>
+      <VsixVersion Condition="'$(VsixVersion)' == ''">$(GitSemVerMajor).$(GitSemVerMinor).$(GitSemVerPatch)</VsixVersion>
     </PropertyGroup>
   </Target>
 

--- a/src/Version.targets
+++ b/src/Version.targets
@@ -57,7 +57,7 @@
       <PackageVersion Condition="'$(GitSemVerDashLabel)' != ''">$(GitBaseVersionMajor).$(GitBaseVersionMinor).$(GitBaseVersionPatch)$(GitSemVerDashLabel).$(GitCommits)+$(SemVerMetadata)</PackageVersion>
       <!-- If shipping stable, semver the package version -->
       <PackageVersion Condition="'$(GitSemVerDashLabel)' == ''">$(GitSemVerMajor).$(GitSemVerMinor).$(GitSemVerPatch)+$(SemVerMetadata)</PackageVersion>
-      <AssemblyVersion>$(GitSemVerMajor).$(GitSemVerMinor).$(GitSemVerPatch)</AssemblyVersion>
+      <AssemblyVersion>$(GitBaseVersionMajor).$(GitBaseVersionMinor).$(GitBaseVersionPatch)</AssemblyVersion>
       <FileVersion>$(GitSemVerMajor).$(GitSemVerMinor).$(GitSemVerPatch)</FileVersion>
       <InformationalVersion>$(PackageVersion)</InformationalVersion>
     </PropertyGroup>


### PR DESCRIPTION
From https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/versioning#assembly-version

So our *assembly* version number will only change when we branch for a release, at which
point we update the GitInfo.txt accordingly. From that point on, only the *file* version
version, package version and informational version will contain the commit height.