### PR TITLE
Remove dependency on System.Reactive

### DIFF
--- a/src/Clide.UnitTests/Clide.UnitTests.csproj
+++ b/src/Clide.UnitTests/Clide.UnitTests.csproj
@@ -11,7 +11,6 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.ComponentModel.Composition" />
-    <Reference Include="Microsoft.Build" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="WindowsBase" />
   </ItemGroup>

--- a/src/Clide.UnitTests/CompositionSpec.cs
+++ b/src/Clide.UnitTests/CompositionSpec.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
 using System.Linq;
-using System.Reactive.Linq;
 using Merq;
 using Microsoft.Internal.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.ComponentModelHost;

--- a/src/Clide.UnitTests/EnumerableExtensions.cs
+++ b/src/Clide.UnitTests/EnumerableExtensions.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Clide
+{
+    public static class EnumerableExtensions
+    {
+        public static IObservable<T> ToObservable<T>(this IEnumerable<T> source)
+            => new EnumerableObservable<T>(source);
+
+        class EnumerableObservable<T> : IObservable<T>
+        {
+            IEnumerable<T> source;
+
+            public EnumerableObservable(IEnumerable<T> source) => this.source = source;
+
+            public IDisposable Subscribe(IObserver<T> observer)
+            {
+                foreach (var item in source)
+                {
+                    observer.OnNext(item);
+                }
+                observer.OnCompleted();
+                return Disposable.Empty;
+            }
+        }
+    }
+}

--- a/src/Clide.UnitTests/Events/ShellInitializedObservableSpec.cs
+++ b/src/Clide.UnitTests/Events/ShellInitializedObservableSpec.cs
@@ -4,7 +4,6 @@ using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell.Interop;
 using Moq;
 using Xunit;
-using System.Reactive.Linq;
 using System.Threading;
 using Microsoft.VisualStudio.Threading;
 
@@ -71,8 +70,8 @@ namespace Clide.Events
                 shell.Verify(x => x.UnadviseShellPropertyChanges(cookie));
 
                 // Subsequent subscription should get one and complete right away.
-
-                var ev = await observable;
+                ShellInitialized ev = default;
+                observable.Subscribe(e => ev = e);
 
                 Assert.Same(data, ev);
             }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -107,7 +107,7 @@
   <PropertyGroup Label="Package Versions">
     <MerqVersion>1.1.1</MerqVersion>
     <MerqVisualStudioVersion>1.1.79</MerqVisualStudioVersion>
-    <RxVersion>4.3.2</RxVersion>
+    <RxVersion>1.0.0-rc.3</RxVersion>
     <FluentInterfaceVersion>2.0.3</FluentInterfaceVersion>
     <StringResourcesVersion>3.1.10</StringResourcesVersion>
     <TracerVersion>2.0.8</TracerVersion>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -3,7 +3,6 @@
   <!-- Common Packages -->
   <ItemGroup>
     <PackageReference Include="Merq" Version="$(MerqVersion)" Pack="false" />
-    <PackageReference Include="System.Reactive.Interfaces" Version="$(RxVersion)" Pack="false" />
     <PackageReference Include="IFluentInterface" Version="$(FluentInterfaceVersion)" Pack="false" />
     <PackageReference Include="netfx-System.StringResources" Version="$(StringResourcesVersion)" Pack="false" />
     <PackageReference Include="System.Diagnostics.Tracer" Version="$(TracerVersion)" Pack="false" />
@@ -24,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(IncludeRx)' == 'true'">
-    <PackageReference Include="System.Reactive.Linq" Version="$(RxVersion)" />
+    <PackageReference Include="RxFree" Version="$(RxVersion)" Pack="false" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IncludeAnalyzers)' == 'true' And '$(TargetOS)' == '$(OS)'">
@@ -33,7 +32,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(IncludeTests)' == 'true' or '$(IncludeIntegrationTests)' == 'true'">
-    <PackageReference Include="System.Reactive.Linq" Version="$(RxVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.msbuild" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />


### PR DESCRIPTION
This heavy dependency was used very sparingly and could be
replaced quite easily for the source-only RxFree instead.

The existing custom observable ShellInitializedObservable
was simplified by leveraging other built-in primitives, and
its unit tests continued to pass with the new changes.