### PR TITLE
Make sure solution is not flagged a project.

### DIFF
--- a/src/Clide.Core.Windows/Solution/Factories/ProjectNodeFactory.cs
+++ b/src/Clide.Core.Windows/Solution/Factories/ProjectNodeFactory.cs
@@ -79,6 +79,10 @@ namespace Clide
             if (!(actualItem.GetActualHierarchy() is IVsProject) && !(hierarchy is FlavoredProjectBase))
                 return false;
 
+            // The solution implements IVsProject2, make sure it isn't classified as a project.
+            if (hierarchy is IVsSolution)
+                return false;
+
             // Finally, solution folders look like projects, but they are not.
             // We need to filter them out too.
             var extenderObject = actualItem.GetExtenderObject();


### PR DESCRIPTION
IVsSolution implements IVsProject2. There is a COM bug where this doesn't respond to IVsProject and fixing it breaks Clide because it then categories the solution as a project.